### PR TITLE
Fix workflow triggers to specify the `main` branch

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -3,7 +3,8 @@ description: Format/lint/type-check the source code, build it and then test it
 
 on:
   push:
-    branches: [$default-branch]
+    branches:
+      - main
   pull_request:
     types:
       - opened

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -2,7 +2,8 @@ name: release-and-publish
 
 on:
   push:
-    branches: [$default-branch]
+    branches:
+      - main
 
   # Allows workflow to be run manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Was using `$default-branch` which only works in workflow templates.

This PR specifies the `main` default branch directly instead, which should fix the triggers.