### PR TITLE
Add handling of unsupported BIK versions, suitable tests, and code coverage

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,14 +1,22 @@
-unbikit  
-[![Conventional Commits badge](https://img.shields.io/badge/Conventional%20Commits-1.0.0-FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)<br>
-![isomorphic](https://img.shields.io/badge/isomorphic-ECDC5A.svg?style=for-the-badge)
-![TypeScript](https://img.shields.io/badge/typescript-007ACC.svg?style=for-the-badge&logo=typescript&logoColor=white)
+# unbikit
+
+[![npm package minimized gzipped size](https://img.shields.io/bundlejs/size/unbikit)](https://bundlejs.com/?q=unbikit)
+![NPM Version](https://img.shields.io/npm/v/unbikit)
+[![NPM License](https://img.shields.io/npm/l/unbikit)](../LICENSE.md)
+<br>
+![isomorphic package badge](https://img.shields.io/badge/isomorphic-ECDC5A.svg?style=for-the-badge)
+![Rolldown](https://img.shields.io/badge/rolldown-FF7E17?style=for-the-badge&logo=rolldown&logoColor=white)
+![TypeScript badge](https://img.shields.io/badge/typescript-007ACC.svg?style=for-the-badge&logo=typescript&logoColor=white)
 [![PNPM badge](https://img.shields.io/badge/pnpm-4a4a4a.svg?style=for-the-badge&logo=pnpm&logoColor=f69220)](https://pnpm.io)
-===
+[![Conventional Commits badge](https://img.shields.io/badge/Conventional%20Commits-1.0.0-FE5196?style=for-the-badge&logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
 
 > [!CAUTION]
 > This package is at a very early development stage. Expect **_major_** API changes!
 
-A decoder for `.bik` video files that can be used to play or transcode videos.
+## Introduction
+
+unbikit (_un-bik-ɪt_) is a decoder for `.bik` video files that can be used to play or transcode
+videos.
 
 ### Features
 
@@ -111,7 +119,7 @@ Sources of reference material about decoding the `.bik` format:
 This software is distributed under Apache License (Version 2.0) or MIT License
 terms, at your option.
 
-See [LICENSE](LICENSE.md) for details.
+See [LICENSE](../LICENSE.md) for details.
 
 **SPDX-License-Identifier: MIT OR Apache-2.0**
 

--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,13 +1,18 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "always-update": true,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,
+  "changelog-type": "github",
   "draft": true,
+  "draft-pull-request": true,
+  "last-release-sha": "6ea8a20d060792f29f77028d341303d535190d25",
   "prerelease": true,
-  "always-update": true,
+  "signoff": "",
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",
+      "include-component-in-tag": false,
       "release-type": "node"
     }
   },

--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -13,13 +13,6 @@ on:
 permissions:
   contents: read
 
-# on:
-#   workflow_run:
-#     workflows: ["Check source code"]
-#     branches: [main]
-#     types:
-#       - completed
-
 jobs:
   check-build-test:
     runs-on: ubuntu-latest
@@ -49,6 +42,9 @@ jobs:
         if: github.event_name == 'pull_request'
         run: pnpm commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
 
+      - name: Format, lint and type-check
+        run: pnpm ci:check
+
       - name: Restore cached test assets
         id: cache-test-assets-restore
         uses: actions/cache/restore@v4
@@ -56,8 +52,8 @@ jobs:
           path: tests/.asset-cache
           key: ${{ runner.os }}-test-assets
 
-      - name: Format, lint, type-check and run tests
-        run: pnpm ci:check
+      - name: Run tests with coverage
+        run: pnpm ci:test
 
       - name: Save test assets in cache
         id: cache-test-assets-save

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # unbikit
 
+[![npm package minimized gzipped size](https://img.shields.io/bundlejs/size/unbikit)](https://bundlejs.com/?q=unbikit)
+
 > ⚠️
 > This package is at a very early development stage. Expect **_major_** API changes!
 
-A decoder for `.bik` video files that can be used to play or transcode videos.
+unbikit (_un-bik-ɪt_) is a decoder for `.bik` video files that can be used to play or transcode
+videos.
 Only version 1 of the format is supported, all revisions except `b`.
 
 Written in TypeScript/JavaScript (no WASM or native code).
@@ -15,7 +18,7 @@ See the [unbikit repository page on GitHub](https://github.com/blennies/unbikit)
 This software is distributed under Apache License (Version 2.0) or MIT License
 terms, at your option.
 
-See [LICENSE](LICENSE.md) for details.
+See [LICENSE](./LICENSE.md) for details.
 
 **SPDX-License-Identifier: MIT OR Apache-2.0**
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "unbikit",
   "version": "0.2.0",
-  "description": "Decoder for .bik format video/audio files.",
+  "description": "Decoder for `.bik` video files.",
   "keywords": [
     "audio",
     "bik",
@@ -31,11 +31,13 @@
     "build": "tsdown",
     "build:docs": "typedoc",
     "check": "biome check && prettier -c . && tsc && vitest run",
-    "ci:check": "biome ci && prettier -c . && tsc && vitest run",
+    "ci:check": "biome ci && prettier -c . && tsc",
     "preview": "vite preview",
     "preview:docs": "vite ./docs --port 6173",
     "test": "vitest --ui",
-    "test:cli": "vitest"
+    "test:coverage": "vitest --ui --coverage --testTimeout 20000",
+    "test:cli": "vitest",
+    "ci:test": "vitest run --coverage --testTimeout 20000"
   },
   "devDependencies": {
     "@arethetypeswrong/core": "0.18.2",
@@ -46,6 +48,7 @@
     "@types/audioworklet": "0.0.91",
     "@types/node": "24.10.1",
     "@types/pngjs": "6.0.5",
+    "@vitest/coverage-v8": "^4.0.8",
     "@vitest/ui": "4.0.8",
     "commitlint": "20.1.0",
     "globals": "16.5.0",
@@ -108,15 +111,14 @@
   ],
   "typedocOptions": {
     "entryPoints": [
-      "./src/bik-decoder.ts",
-      "./src/bik-video-decoder.ts",
-      "./src/bik-audio-decoder.ts"
+      "./src/bik-decoder.ts"
     ],
     "includeVersion": true,
     "name": "unbikit",
     "plugin": [
       "typedoc-theme-fresh"
     ],
+    "readme": ".github/README.md",
     "theme": "fresh"
   },
   "commitlint": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@types/pngjs':
         specifier: 6.0.5
         version: 6.0.5
+      '@vitest/coverage-v8':
+        specifier: ^4.0.8
+        version: 4.0.8(vitest@4.0.8)
       '@vitest/ui':
         specifier: 4.0.8
         version: 4.0.8(vitest@4.0.8)
@@ -120,6 +123,10 @@ packages:
   '@babel/types@7.28.5':
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@biomejs/biome@2.3.5':
     resolution: {integrity: sha512-HvLhNlIlBIbAV77VysRIBEwp55oM/QAjQEin74QQX9Xb259/XP/D5AGGnZMOyF1el4zcvlNYYR3AyTMUV3ILhg==}
@@ -700,6 +707,15 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
+  '@vitest/coverage-v8@4.0.8':
+    resolution: {integrity: sha512-wQgmtW6FtPNn4lWUXi8ZSYLpOIb92j3QCujxX3sQ81NTfQ/ORnE0HtK7Kqf2+7J9jeveMGyGyc4NWc5qy3rC4A==}
+    peerDependencies:
+      '@vitest/browser': 4.0.8
+      vitest: 4.0.8
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.0.8':
     resolution: {integrity: sha512-Rv0eabdP/xjAHQGr8cjBm+NnLHNoL268lMDK85w2aAGLFoVKLd8QGnVon5lLtkXQCoYaNL0wg04EGnyKkkKhPA==}
 
@@ -771,6 +787,9 @@ packages:
   ast-kit@2.2.0:
     resolution: {integrity: sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==}
     engines: {node: '>=20.19.0'}
+
+  ast-v8-to-istanbul@0.3.8:
+    resolution: {integrity: sha512-szgSZqUxI5T8mLKvS7WTjF9is+MVbOeLADU73IseOcrqhxr/VAvy6wfoVE39KnKzA7JRhjF5eUagNlHwvZPlKQ==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -978,8 +997,15 @@ packages:
     resolution: {integrity: sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==}
     engines: {node: '>=18'}
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -1005,6 +1031,22 @@ packages:
 
   is-text-path@2.0.0:
     resolution: {integrity: sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
 
   jiti@2.6.1:
@@ -1152,6 +1194,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.1:
+    resolution: {integrity: sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   markdown-it@14.1.0:
     resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
@@ -1391,6 +1440,10 @@ packages:
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
   tagged-tag@1.0.0:
@@ -1676,6 +1729,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@biomejs/biome@2.3.5':
     optionalDependencies:
@@ -2138,6 +2193,23 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
+  '@vitest/coverage-v8@4.0.8(vitest@4.0.8)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.0.8
+      ast-v8-to-istanbul: 0.3.8
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magicast: 0.5.1
+      std-env: 3.10.0
+      tinyrainbow: 3.0.3
+      vitest: 4.0.8(@types/node@24.10.1)(@vitest/ui@4.0.8)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@4.0.8':
     dependencies:
       '@standard-schema/spec': 1.0.0
@@ -2220,6 +2292,12 @@ snapshots:
     dependencies:
       '@babel/parser': 7.28.5
       pathe: 2.0.3
+
+  ast-v8-to-istanbul@0.3.8:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 9.0.1
 
   balanced-match@1.0.2: {}
 
@@ -2407,7 +2485,11 @@ snapshots:
 
   globals@16.5.0: {}
 
+  has-flag@4.0.0: {}
+
   hookable@5.5.3: {}
+
+  html-escaper@2.0.2: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -2427,6 +2509,27 @@ snapshots:
   is-text-path@2.0.0:
     dependencies:
       text-extensions: 2.4.0
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
 
   jiti@2.6.1: {}
 
@@ -2530,6 +2633,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.1:
+    dependencies:
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.3
 
   markdown-it@14.1.0:
     dependencies:
@@ -2750,6 +2863,10 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
 
   tagged-tag@1.0.0: {}
 

--- a/src/bik-audio-decoder.ts
+++ b/src/bik-audio-decoder.ts
@@ -81,9 +81,9 @@ class BikAudioDecoder {
     const output = this.#output;
     const allOutput: Float32Array[][] = [];
 
-    while (reader.bitsLeft() > 0) {
+    while (reader.bitsLeft_() > 0) {
       if (this.#useDCT) {
-        reader.skip(2);
+        reader.skip_(2);
       }
 
       for (let ch = 0; ch < this.#numInternalChannels; ch++) {
@@ -96,7 +96,7 @@ class BikAudioDecoder {
         // Calculate the quantizers for each band for this frame
         const quant = new Float32Array(this.#numBands);
         for (let i = 0; i < quant.length; i++) {
-          quant[i] = this.#quantTable[Math.min(reader.readBits(8), 95)] as number;
+          quant[i] = this.#quantTable[Math.min(reader.readBits_(8), 95)] as number;
         }
 
         let k = 0;
@@ -105,8 +105,8 @@ class BikAudioDecoder {
 
         while (i < this.#frameLen) {
           let j: number;
-          if (reader.readBit()) {
-            const v = reader.readBits(4) as IntRange<0, 16>;
+          if (reader.readBit_()) {
+            const v = reader.readBits_(4) as IntRange<0, 16>;
             j = i + AUDIO_RLE_LENGTH_TABLE[v];
           } else {
             j = i + 8;
@@ -114,7 +114,7 @@ class BikAudioDecoder {
 
           j = ~~Math.min(j, this.#frameLen);
 
-          const width = reader.readBits(4);
+          const width = reader.readBits_(4);
           if (width === 0) {
             coeffs.fill(0, i, j);
             i = j;
@@ -126,9 +126,9 @@ class BikAudioDecoder {
               if (this.#bands[k] === i) {
                 q = quant[k++] ?? 0;
               }
-              const coeff = reader.readBits(width);
+              const coeff = reader.readBits_(width);
               if (coeff) {
-                const sign = reader.readBit();
+                const sign = reader.readBit_();
                 coeffs[i] = sign ? -q * coeff : q * coeff;
               } else {
                 coeffs[i] = 0;
@@ -190,7 +190,7 @@ class BikAudioDecoder {
       allOutput.push(outputBlock);
 
       this.#first = false;
-      reader.align32();
+      reader.align32_();
     }
 
     return allOutput;
@@ -203,9 +203,9 @@ class BikAudioDecoder {
    * @returns The floating point value as a regular 64-bit double.
    */
   #getFloat(reader: BitReader) {
-    const power = reader.readBits(5);
-    const f = reader.readBits(23) * Math.pow(2, power - 23);
-    return reader.readBit() ? -f : f;
+    const power = reader.readBits_(5);
+    const f = reader.readBits_(23) * Math.pow(2, power - 23);
+    return reader.readBit_() ? -f : f;
   }
 }
 

--- a/src/bik-decoder-utils.ts
+++ b/src/bik-decoder-utils.ts
@@ -12,13 +12,13 @@ class BitReader {
     this.#buffer = buffer;
   }
 
-  reset(buffer: Uint8Array | Uint8ClampedArray): void {
+  reset_(buffer: Uint8Array | Uint8ClampedArray): void {
     this.#buffer = buffer;
     this.#pos = 0;
     this.#bitPos = 0;
   }
 
-  readBits(n: number): number {
+  readBits_(n: number): number {
     let result = 0;
     let bitsRead = 0;
     let bitsRemaining = n;
@@ -41,7 +41,7 @@ class BitReader {
     return result;
   }
 
-  readBit(): number {
+  readBit_(): number {
     const bit = ((this.#buffer[this.#pos] ?? 0) >>> this.#bitPos++) & 1;
     if (this.#bitPos >= 8) {
       this.#pos++;
@@ -50,11 +50,11 @@ class BitReader {
     return bit;
   }
 
-  tell(): number {
+  tell_(): number {
     return this.#pos * 8 + this.#bitPos;
   }
 
-  skip(n: number): void {
+  skip_(n: number): void {
     this.#bitPos += n;
     while (this.#bitPos >= 8) {
       this.#pos++;
@@ -62,24 +62,24 @@ class BitReader {
     }
   }
 
-  align32(): void {
-    const n = (32 - (this.tell() & 31)) & 31;
-    if (n > 0) this.skip(n);
+  align32_(): void {
+    const n = (32 - (this.tell_() & 31)) & 31;
+    if (n > 0) this.skip_(n);
   }
 
-  bitsLeft(): number {
+  bitsLeft_(): number {
     return (this.#buffer.length - this.#pos) * 8 - this.#bitPos;
   }
 
-  applySign(v: number): number {
-    return this.readBit() ? -v : v;
+  applySign_(v: number): number {
+    return this.readBit_() ? -v : v;
   }
 
-  savePos(): { pos: number; bitPos: number } {
+  savePos_(): { pos: number; bitPos: number } {
     return { pos: this.#pos, bitPos: this.#bitPos };
   }
 
-  restorePos({ pos, bitPos }: { pos: number; bitPos: number }): void {
+  restorePos_({ pos, bitPos }: { pos: number; bitPos: number }): void {
     this.#pos = pos;
     this.#bitPos = bitPos;
   }

--- a/tests/__snapshots__/main.test.ts.snap
+++ b/tests/__snapshots__/main.test.ts.snap
@@ -1,71 +1,71 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`decoding of media file 'testfile01' > should decode frames from across the file (testfile01) > screenshot_testfile01_frame_0.png 1`] = `"cb41ceeabe67fb4aa21fd2343f2d9b4f2a8555d07080ba947fd17b3710a5fe33"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile01) > screenshot_testfile01_frame_0.png 1`] = `"cb41ceeabe67fb4aa21fd2343f2d9b4f2a8555d07080ba947fd17b3710a5fe33"`;
 
-exports[`decoding of media file 'testfile01' > should decode frames from across the file (testfile01) > screenshot_testfile01_frame_125.png 1`] = `"92a1945152ff1c73e3a4a91f3557c36800e99145b9097da0a621392014ea6e76"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile01) > screenshot_testfile01_frame_125.png 1`] = `"92a1945152ff1c73e3a4a91f3557c36800e99145b9097da0a621392014ea6e76"`;
 
-exports[`decoding of media file 'testfile01' > should decode frames from across the file (testfile01) > screenshot_testfile01_frame_250.png 1`] = `"9fdeb95ef7fc41467ad801a388a72e92146832f44bca548e12de83f7379a0337"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile01) > screenshot_testfile01_frame_250.png 1`] = `"9fdeb95ef7fc41467ad801a388a72e92146832f44bca548e12de83f7379a0337"`;
 
-exports[`decoding of media file 'testfile01' > should decode frames from across the file (testfile01) > screenshot_testfile01_frame_375.png 1`] = `"5795e5cb3cc8566e581f0cb517354e620712ef06bdc91e16c8c245a5aceddff9"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile01) > screenshot_testfile01_frame_375.png 1`] = `"5795e5cb3cc8566e581f0cb517354e620712ef06bdc91e16c8c245a5aceddff9"`;
 
-exports[`decoding of media file 'testfile01' > should decode frames from across the file (testfile01) > screenshot_testfile01_frame_500.png 1`] = `"09dca7cfe412193f9a93fff12f5e701bcd07afdd2e9282b0113447a55fe191ee"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile01) > screenshot_testfile01_frame_500.png 1`] = `"09dca7cfe412193f9a93fff12f5e701bcd07afdd2e9282b0113447a55fe191ee"`;
 
-exports[`decoding of media file 'testfile02' > should decode frames from across the file (testfile02) > screenshot_testfile02_frame_0.png 1`] = `"f3af0ab2b08a5de7419316d9ac0d2c38c118ae95e3a8547b03b2ea23e75c4484"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile02) > screenshot_testfile02_frame_0.png 1`] = `"f3af0ab2b08a5de7419316d9ac0d2c38c118ae95e3a8547b03b2ea23e75c4484"`;
 
-exports[`decoding of media file 'testfile02' > should decode frames from across the file (testfile02) > screenshot_testfile02_frame_42.png 1`] = `"ec33abba11e19da2b3effc10b1c14e5d7b2bf8acc1cbff1615ed55109d8717c2"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile02) > screenshot_testfile02_frame_42.png 1`] = `"ec33abba11e19da2b3effc10b1c14e5d7b2bf8acc1cbff1615ed55109d8717c2"`;
 
-exports[`decoding of media file 'testfile02' > should decode frames from across the file (testfile02) > screenshot_testfile02_frame_84.png 1`] = `"229b794f104cfd0cd58397cc484e50d2c73082701529bc70f917650efba0f8c1"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile02) > screenshot_testfile02_frame_84.png 1`] = `"229b794f104cfd0cd58397cc484e50d2c73082701529bc70f917650efba0f8c1"`;
 
-exports[`decoding of media file 'testfile02' > should decode frames from across the file (testfile02) > screenshot_testfile02_frame_126.png 1`] = `"67dd689300abff49e9ef684f176fa66737a37b2f60e1c061c84d291fa677c0d4"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile02) > screenshot_testfile02_frame_126.png 1`] = `"67dd689300abff49e9ef684f176fa66737a37b2f60e1c061c84d291fa677c0d4"`;
 
-exports[`decoding of media file 'testfile02' > should decode frames from across the file (testfile02) > screenshot_testfile02_frame_168.png 1`] = `"f3af0ab2b08a5de7419316d9ac0d2c38c118ae95e3a8547b03b2ea23e75c4484"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile02) > screenshot_testfile02_frame_168.png 1`] = `"f3af0ab2b08a5de7419316d9ac0d2c38c118ae95e3a8547b03b2ea23e75c4484"`;
 
-exports[`decoding of media file 'testfile03' > should decode frames from across the file (testfile03) > screenshot_testfile03_frame_0.png 1`] = `"1094047983b8a6e3e106dcfeff5ae2a30b164306272b8c21c072154731defd4f"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile03) > screenshot_testfile03_frame_0.png 1`] = `"1094047983b8a6e3e106dcfeff5ae2a30b164306272b8c21c072154731defd4f"`;
 
-exports[`decoding of media file 'testfile03' > should decode frames from across the file (testfile03) > screenshot_testfile03_frame_62.png 1`] = `"544382683d9f90900fe6626abfd7e3b0fa1f95f400c79155f65adbdf855919cb"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile03) > screenshot_testfile03_frame_62.png 1`] = `"544382683d9f90900fe6626abfd7e3b0fa1f95f400c79155f65adbdf855919cb"`;
 
-exports[`decoding of media file 'testfile03' > should decode frames from across the file (testfile03) > screenshot_testfile03_frame_124.png 1`] = `"544382683d9f90900fe6626abfd7e3b0fa1f95f400c79155f65adbdf855919cb"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile03) > screenshot_testfile03_frame_124.png 1`] = `"544382683d9f90900fe6626abfd7e3b0fa1f95f400c79155f65adbdf855919cb"`;
 
-exports[`decoding of media file 'testfile03' > should decode frames from across the file (testfile03) > screenshot_testfile03_frame_186.png 1`] = `"544382683d9f90900fe6626abfd7e3b0fa1f95f400c79155f65adbdf855919cb"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile03) > screenshot_testfile03_frame_186.png 1`] = `"544382683d9f90900fe6626abfd7e3b0fa1f95f400c79155f65adbdf855919cb"`;
 
-exports[`decoding of media file 'testfile03' > should decode frames from across the file (testfile03) > screenshot_testfile03_frame_248.png 1`] = `"e03d205fe4a2cd2840cdb1d0199a2c35b58c85a104eebbcb380026a3f519e74f"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile03) > screenshot_testfile03_frame_248.png 1`] = `"e03d205fe4a2cd2840cdb1d0199a2c35b58c85a104eebbcb380026a3f519e74f"`;
 
-exports[`decoding of media file 'testfile04' > should decode frames from across the file (testfile04) > screenshot_testfile04_frame_0.png 1`] = `"df56de7a7a097ebeffb4335851ad9903a7f4ba58fa39f185311ff1fc8856b4c2"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile04) > screenshot_testfile04_frame_0.png 1`] = `"df56de7a7a097ebeffb4335851ad9903a7f4ba58fa39f185311ff1fc8856b4c2"`;
 
-exports[`decoding of media file 'testfile04' > should decode frames from across the file (testfile04) > screenshot_testfile04_frame_125.png 1`] = `"b354a45ce005a7e7fed00adc7e304f296d00f0725d1991ca6051aac66bfcecfc"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile04) > screenshot_testfile04_frame_125.png 1`] = `"b354a45ce005a7e7fed00adc7e304f296d00f0725d1991ca6051aac66bfcecfc"`;
 
-exports[`decoding of media file 'testfile04' > should decode frames from across the file (testfile04) > screenshot_testfile04_frame_250.png 1`] = `"ff5bff3a3bd28a526bc4b7a995a84afbd19423823216bdcbc794665f6e26bfc4"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile04) > screenshot_testfile04_frame_250.png 1`] = `"ff5bff3a3bd28a526bc4b7a995a84afbd19423823216bdcbc794665f6e26bfc4"`;
 
-exports[`decoding of media file 'testfile04' > should decode frames from across the file (testfile04) > screenshot_testfile04_frame_375.png 1`] = `"168383cccef89515c39aa7abe25aa20f980d48c8195034e9c5730a4089793d85"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile04) > screenshot_testfile04_frame_375.png 1`] = `"168383cccef89515c39aa7abe25aa20f980d48c8195034e9c5730a4089793d85"`;
 
-exports[`decoding of media file 'testfile04' > should decode frames from across the file (testfile04) > screenshot_testfile04_frame_500.png 1`] = `"e33727d883f807b80c1e2154773c8c1f7024b7b2e97b80ee671e8071c8fcad81"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile04) > screenshot_testfile04_frame_500.png 1`] = `"e33727d883f807b80c1e2154773c8c1f7024b7b2e97b80ee671e8071c8fcad81"`;
 
-exports[`decoding of media file 'testfile05' > should decode frames from across the file (testfile05) > screenshot_testfile05_frame_0.png 1`] = `"cb41ceeabe67fb4aa21fd2343f2d9b4f2a8555d07080ba947fd17b3710a5fe33"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile05) > screenshot_testfile05_frame_0.png 1`] = `"cb41ceeabe67fb4aa21fd2343f2d9b4f2a8555d07080ba947fd17b3710a5fe33"`;
 
-exports[`decoding of media file 'testfile05' > should decode frames from across the file (testfile05) > screenshot_testfile05_frame_66.png 1`] = `"7d967f44116d4bd9ad812ad1c16aefcde52468f6db95a3b0bca9eaf1e53098b6"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile05) > screenshot_testfile05_frame_66.png 1`] = `"7d967f44116d4bd9ad812ad1c16aefcde52468f6db95a3b0bca9eaf1e53098b6"`;
 
-exports[`decoding of media file 'testfile05' > should decode frames from across the file (testfile05) > screenshot_testfile05_frame_132.png 1`] = `"0edcadae7933ac75db4dacc3b42be1bb7668009003ead3b5a2f12f060ffccab5"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile05) > screenshot_testfile05_frame_132.png 1`] = `"0edcadae7933ac75db4dacc3b42be1bb7668009003ead3b5a2f12f060ffccab5"`;
 
-exports[`decoding of media file 'testfile05' > should decode frames from across the file (testfile05) > screenshot_testfile05_frame_198.png 1`] = `"749666dc75cd270b32555bc5817920167c9c5907f320e9e2ccd818cc21b0481d"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile05) > screenshot_testfile05_frame_198.png 1`] = `"749666dc75cd270b32555bc5817920167c9c5907f320e9e2ccd818cc21b0481d"`;
 
-exports[`decoding of media file 'testfile05' > should decode frames from across the file (testfile05) > screenshot_testfile05_frame_264.png 1`] = `"cb41ceeabe67fb4aa21fd2343f2d9b4f2a8555d07080ba947fd17b3710a5fe33"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile05) > screenshot_testfile05_frame_264.png 1`] = `"cb41ceeabe67fb4aa21fd2343f2d9b4f2a8555d07080ba947fd17b3710a5fe33"`;
 
-exports[`decoding of media file 'testfile06' > should decode frames from across the file (testfile06) > screenshot_testfile06_frame_0.png 1`] = `"e8817a7782d0cabbdb5e1d2cad4995c67146a7765bbaf185ff9fe3f9ff43797d"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile06) > screenshot_testfile06_frame_0.png 1`] = `"e8817a7782d0cabbdb5e1d2cad4995c67146a7765bbaf185ff9fe3f9ff43797d"`;
 
-exports[`decoding of media file 'testfile06' > should decode frames from across the file (testfile06) > screenshot_testfile06_frame_69.png 1`] = `"e2a6c449292f77ef98f890e837da6a3257619c8f9c756ad6d8771fb47da9a260"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile06) > screenshot_testfile06_frame_69.png 1`] = `"e2a6c449292f77ef98f890e837da6a3257619c8f9c756ad6d8771fb47da9a260"`;
 
-exports[`decoding of media file 'testfile06' > should decode frames from across the file (testfile06) > screenshot_testfile06_frame_138.png 1`] = `"43e0fc4e1d4c962cad5c940d629f211557b9cc9cde1ba8e0e3c60a8de40c0394"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile06) > screenshot_testfile06_frame_138.png 1`] = `"43e0fc4e1d4c962cad5c940d629f211557b9cc9cde1ba8e0e3c60a8de40c0394"`;
 
-exports[`decoding of media file 'testfile06' > should decode frames from across the file (testfile06) > screenshot_testfile06_frame_207.png 1`] = `"35c612115979c5aabf3136b26103679df4ac3f00da311875682506ede6219088"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile06) > screenshot_testfile06_frame_207.png 1`] = `"35c612115979c5aabf3136b26103679df4ac3f00da311875682506ede6219088"`;
 
-exports[`decoding of media file 'testfile06' > should decode frames from across the file (testfile06) > screenshot_testfile06_frame_276.png 1`] = `"df56de7a7a097ebeffb4335851ad9903a7f4ba58fa39f185311ff1fc8856b4c2"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile06) > screenshot_testfile06_frame_276.png 1`] = `"df56de7a7a097ebeffb4335851ad9903a7f4ba58fa39f185311ff1fc8856b4c2"`;
 
-exports[`decoding of media file 'testfile07' > should decode frames from across the file (testfile07) > screenshot_testfile07_frame_0.png 1`] = `"76fdd10e3e3b47da01c4fc236be78fc6482f6e07175da571baa8fd7e1d9b4485"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile07) > screenshot_testfile07_frame_0.png 1`] = `"76fdd10e3e3b47da01c4fc236be78fc6482f6e07175da571baa8fd7e1d9b4485"`;
 
-exports[`decoding of media file 'testfile07' > should decode frames from across the file (testfile07) > screenshot_testfile07_frame_125.png 1`] = `"136afc27e6a0a4828a4a043c746ca96a19ae113c84922f4319c40d01593e964e"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile07) > screenshot_testfile07_frame_125.png 1`] = `"136afc27e6a0a4828a4a043c746ca96a19ae113c84922f4319c40d01593e964e"`;
 
-exports[`decoding of media file 'testfile07' > should decode frames from across the file (testfile07) > screenshot_testfile07_frame_250.png 1`] = `"958fe3939bf2412a5e70279e0c6b82dd1a8abb6a53a312487391617e2e2dbe8c"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile07) > screenshot_testfile07_frame_250.png 1`] = `"958fe3939bf2412a5e70279e0c6b82dd1a8abb6a53a312487391617e2e2dbe8c"`;
 
-exports[`decoding of media file 'testfile07' > should decode frames from across the file (testfile07) > screenshot_testfile07_frame_375.png 1`] = `"49bd2c5ddb417ef88e25cdd1b662eeb6a44abf347fd50c0be15a63783afbe727"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile07) > screenshot_testfile07_frame_375.png 1`] = `"49bd2c5ddb417ef88e25cdd1b662eeb6a44abf347fd50c0be15a63783afbe727"`;
 
-exports[`decoding of media file 'testfile07' > should decode frames from across the file (testfile07) > screenshot_testfile07_frame_500.png 1`] = `"7a2e151db11bc238c7f8bc41100ffdbc01f903e0cdc101f52381be9021a5c5b4"`;
+exports[`decoding of BIK 1 (d, f, g, h, i) media files > should decode frames from across the file (testfile07) > screenshot_testfile07_frame_500.png 1`] = `"7a2e151db11bc238c7f8bc41100ffdbc01f903e0cdc101f52381be9021a5c5b4"`;

--- a/tests/common.ts
+++ b/tests/common.ts
@@ -17,6 +17,8 @@ export const ASSET_CACHE_PATH: string = path.join(import.meta.dirname, ".asset-c
  */
 const MEDIA_SRC_URLS = {
   site01: "https://sembiance.com/fileFormatSamples/video/bink/",
+  site02: "https://samples.ffmpeg.org/game-formats/bink/",
+  site03: "https://samples.ffmpeg.org/game-formats/bink2/",
 } as const;
 type MediaSrc = keyof typeof MEDIA_SRC_URLS;
 
@@ -26,12 +28,6 @@ const MEDIA_FILES_INFO = {
     site: "site01",
     sha256: "d642466b19d8310a49d7b364fb8a088086e6108647d10a547ec72f595e0097c3",
   },
-  // This test file is BIK 1b format, which we don't support.
-  // testfile01b: {
-  //   filename: "DEFENDALL.BIK",
-  //   site: "site01",
-  //   sha256: "85f215f72d50c9fb14995707778ef2149a33b197070765cd901edb3e2f2733d7",
-  // },
   testfile02: {
     filename: "OpenPt1.bik",
     site: "site01",
@@ -61,6 +57,18 @@ const MEDIA_FILES_INFO = {
     filename: "phar_intro.bik",
     site: "site01",
     sha256: "c58b6b4cd8afb843e6a004c516e59de100494eafe75a295996af2f29047c4e1b",
+  },
+  // This test file is BIK 1b format, which we don't support.
+  testfile08bk1b: {
+    filename: "DEFENDALL.BIK",
+    site: "site01",
+    sha256: "85f215f72d50c9fb14995707778ef2149a33b197070765cd901edb3e2f2733d7",
+  },
+  // This test file is BIK 2 format, which we don't support
+  testfile09bk2: {
+    filename: "Open_Logos_partial.bik",
+    site: "site03",
+    sha256: "62edb59b3b36f1eb2ddffac39d62ab45cf8f3640f8aac7989882e9d20e911574",
   },
 } as const;
 type MediaFileIndex = keyof typeof MEDIA_FILES_INFO;
@@ -256,9 +264,9 @@ const frameToPng = (frame: BikFrame | null | undefined): Uint8Array<ArrayBuffer>
 /**
  * Extra fixtures.
  */
-type Fixtures = {};
+// type Fixtures = {};
 
-const test: TestAPI<Fixtures> = baseTest.extend<Fixtures>({});
-const it: TestAPI<Fixtures> = test;
+// const test: TestAPI<Fixtures> = baseTest.extend<Fixtures>({});
+// const it: TestAPI<Fixtures> = test;
 
-export { frameToPng, getShaSum, yuv420PlanarToRgb, mediaFiles, it, test };
+export { frameToPng, getShaSum, yuv420PlanarToRgb, mediaFiles, type MediaFile };

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -1,46 +1,98 @@
 import { objectEntries } from "ts-extras";
-import { describe } from "vitest";
+import { suite, test } from "vitest";
+// import type {Fixtures}
 import { BikDecoder } from "../src/bik-decoder.ts";
-import { frameToPng, getShaSum, it, mediaFiles } from "./common.ts";
+import { frameToPng, getShaSum, type MediaFile, mediaFiles } from "./common.ts";
 
-describe.each(
-  objectEntries(mediaFiles).map(([name, file]) => ({
-    name,
-    file,
-  })),
-)(
-  "decoding of media file $name",
-  async ({ name, file }) => {
-    const decoder = await BikDecoder.open(file.getStreamFn());
-    const header = decoder?.header;
-    const numFrames = Math.min((header?.numFrames ?? 1) - 1, 500);
-    const frameQuarters = ~~(numFrames / 4);
+const getMediaFileDecoder = async (file: MediaFile): Promise<BikDecoder> => {
+  return await BikDecoder.open(file.getStreamFn());
+};
+const fetchSelectionOfFrames = async (
+  fileIndex: keyof typeof mediaFiles,
+  { annotate, expect }: any,
+): Promise<void> => {
+  const file = mediaFiles[fileIndex];
+  const decoder = await getMediaFileDecoder(mediaFiles[fileIndex]);
+  const header = decoder?.header;
+  const numFrames = Math.min((header?.numFrames ?? 1) - 1, 500);
+  const frameQuarters = ~~(numFrames / 4);
+  expect(header).toBeTruthy();
+  annotate(
+    `header info for ${file.name} -- version: ${header?.version}${String.fromCharCode(header?.subVersion ?? 63)}, frames: ${header?.numFrames}, image size: ${header?.width}x${header?.height}`,
+  );
 
-    it(`should decode the header (${name})`, async ({ annotate, expect }) => {
-      expect(header).toBeTruthy();
-      annotate(
-        `header info for ${name} -- version: ${header?.version}${String.fromCharCode(header?.subVersion ?? 63)}, frames: ${header?.numFrames}, image size: ${header?.width}x${header?.height}`,
-      );
+  let frameNum = 0;
+  while (frameNum <= frameQuarters * 4) {
+    const frame = await decoder.getNextFrame();
+    expect(frame?.audioTracks).toBeDefined();
+    expect(frame?.videoFrame).toBeDefined();
+
+    const frameName = `screenshot_${file.name}_frame_${frameNum}.png`;
+    const png = frameToPng(frame);
+    annotate(frameName, {
+      body: png,
+      contentType: "image/png",
     });
+    expect(await getShaSum(png)).toMatchSnapshot(frameName);
+    await decoder.skipFrames(frameQuarters - 1);
+    frameNum += frameQuarters;
+  }
+};
 
-    it(`should decode frames from across the file (${name})`, async ({ annotate, expect }) => {
-      let frameNum = 0;
-      while (frameNum <= frameQuarters * 4) {
-        const frame = await decoder.getNextFrame();
-        expect(frame?.audioTracks).toBeDefined();
-        expect(frame?.videoFrame).toBeDefined();
+suite("decoding of BIK 1 (d, f, g, h, i) media files", async () => {
+  test("should decode frames from across the file (testfile01)", async ({ annotate, expect }) => {
+    await fetchSelectionOfFrames("testfile01", { annotate, expect });
+  });
+  test("should decode frames from across the file (testfile02)", async ({ annotate, expect }) => {
+    await fetchSelectionOfFrames("testfile02", { annotate, expect });
+  });
+  test("should decode frames from across the file (testfile03)", async ({ annotate, expect }) => {
+    await fetchSelectionOfFrames("testfile03", { annotate, expect });
+  });
+  test("should decode frames from across the file (testfile04)", async ({ annotate, expect }) => {
+    await fetchSelectionOfFrames("testfile04", { annotate, expect });
+  });
+  test("should decode frames from across the file (testfile05)", async ({ annotate, expect }) => {
+    await fetchSelectionOfFrames("testfile05", { annotate, expect });
+  });
+  test("should decode frames from across the file (testfile06)", async ({ annotate, expect }) => {
+    await fetchSelectionOfFrames("testfile06", { annotate, expect });
+  });
+  test("should decode frames from across the file (testfile07)", async ({ annotate, expect }) => {
+    await fetchSelectionOfFrames("testfile07", { annotate, expect });
+  });
+});
 
-        const frameName = `screenshot_${name}_frame_${frameNum}.png`;
-        const png = frameToPng(frame);
-        expect(await getShaSum(png)).toMatchSnapshot(frameName);
-        annotate(frameName, {
-          body: png,
-          contentType: "image/png",
-        });
-        await decoder.skipFrames(frameQuarters - 1);
-        frameNum += frameQuarters;
-      }
-    });
-  },
-  10000,
-);
+suite("decoding of media files of unsupported BIK versions", async () => {
+  test("should decode header but refuse to decode BIK 1b (testfile08bk1b)", async ({
+    annotate,
+    expect,
+  }) => {
+    const decoder = await getMediaFileDecoder(mediaFiles["testfile08bk1b"]);
+    const header = decoder.header;
+    annotate(
+      `header info -- version: ${header?.version}${String.fromCharCode(header?.subVersion ?? 63)}, frames: ${header?.numFrames}, image size: ${header?.width}x${header?.height}`,
+    );
+    expect(header?.version).toEqual(1);
+    expect(header?.subVersion).toEqual("b".charCodeAt(0));
+    expect(decoder.isSupported).toEqual(false);
+    expect(await decoder.getNextFrame()).toBeNull();
+    await decoder.skipFrames(1000);
+  });
+
+  test("should decode header but refuse to decode BIK 2a (testfile09bk2)", async ({
+    annotate,
+    expect,
+  }) => {
+    const decoder = await getMediaFileDecoder(mediaFiles["testfile09bk2"]);
+    const header = decoder.header;
+    annotate(
+      `header info -- version: ${header?.version}${String.fromCharCode(header?.subVersion ?? 63)}, frames: ${header?.numFrames}, image size: ${header?.width}x${header?.height}`,
+    );
+    expect(header?.version).toEqual(2);
+    expect(header?.subVersion).toEqual("a".charCodeAt(0));
+    expect(decoder.isSupported).toEqual(false);
+    expect(await decoder.getNextFrame()).toBeNull();
+    await decoder.skipFrames(1000);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,7 @@ import esbuild from "rollup-plugin-esbuild";
 import { defineConfig, type Plugin, type ViteUserConfigExport } from "vitest/config";
 import { commonBuildInputOptions, commonBuildTestConfig } from "./common-build-test.config.ts";
 
-const config: ViteUserConfigExport = defineConfig(({ mode }) => {
+const config: ViteUserConfigExport = defineConfig(() => {
   // const isProduction = mode === "production";
 
   return {
@@ -10,27 +10,27 @@ const config: ViteUserConfigExport = defineConfig(({ mode }) => {
     plugins: [
       esbuild({
         mangleCache: {
-          align32: "u",
-          applySign: "i",
-          bitPos: "A",
-          bitsLeft: "f",
-          calculate: "c",
-          curDec: "e",
-          curPtr: "a",
-          getHuff: "r",
-          items: "s",
-          pos: "b",
-          readBit: "n",
-          readBits: "t",
-          reset: "l",
-          restorePos: "y",
-          savePos: "d",
-          skip: "h",
-          tell: "m",
-          tree: "o",
+          align32_: "u",
+          applySign_: "i",
+          bitPos_: "A",
+          bitsLeft_: "f",
+          calculate_: "c",
+          curDec_: "e",
+          curPtr_: "a",
+          getHuff_: "r",
+          items_: "s",
+          pos_: "b",
+          readBit_: "n",
+          readBits_: "t",
+          reset_: "l",
+          restorePos_: "y",
+          savePos_: "d",
+          skip_: "h",
+          tell_: "m",
+          tree_: "o",
         },
         mangleProps:
-          /^align32|applySign|bitPos|bitsLeft|calculate|curDec|curPtr|getHuff|items|pos|readBits?|reset|restorePos|savePos|skip|tell|tree$/,
+          /^(align32|applySign|bitPos|bitsLeft|calculate|curDec|curPtr|getHuff|items|pos|readBits?|reset|restorePos|savePos|skip|tell|tree)_$/,
         mangleQuoted: true,
         platform: "neutral",
         reserveProps: /^postMessage$/,
@@ -39,6 +39,7 @@ const config: ViteUserConfigExport = defineConfig(({ mode }) => {
     ],
     rolldownOptions: commonBuildInputOptions,
     test: {
+      coverage: { exclude: ["./tests/**/*"] },
       // globalSetup: "tests/global-setup.ts",
       // projects: [
       //   { extends: true, test: { name: "dev" } },


### PR DESCRIPTION
feat: handle unsupported BIK versions and indicate status via the `isSupported` property

Add more robust handling of unsupported BIK versions. Process the header of unsupported versions and/or sub-versions, but refuse to perform any other operations. Indicate the level of support via the new `isSupported` property of the decoder class.

Unsupported BIK versions are version 1b and version 2.

refactor: modify decoder internal property names to avoid transpilation issues in tests

test: refactor all tests and add tests for BIK 1b and BIK2

test: add code coverage collection to tests

ci: enable code coverage collection in CI

docs: add badges to README and update structure