### PR TITLE
When publishing releases, deploy the documentation to GitHub Pages

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -3,10 +3,9 @@
   "always-update": true,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,
-  "changelog-type": "github",
+  "changelog-type": "default",
   "draft": true,
   "draft-pull-request": true,
-  "last-release-sha": "6d564dd873da1c95e5cbfb4bdb1ec16d865dcf73",
   "prerelease": true,
   "signoff": "",
   "packages": {

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -12,11 +12,14 @@ permissions:
   contents: write
   id-token: write # Required for OIDC when publishing to npm
   issues: write
+  pages: write
   pull-requests: write
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
+    outputs:
+      release-created: ${{ steps.release.outputs.release_created }}
     steps:
       - uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42
         id: app-token
@@ -31,31 +34,69 @@ jobs:
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
 
+  publish-npm:
+    runs-on: ubuntu-latest
+    needs: release
+    if: ${{needs.release.outputs.release-created}}
+    steps:
       - name: Checkout
-        if: ${{ steps.release.outputs.release_created }}
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Install pnpm
-        if: ${{ steps.release.outputs.release_created }}
         uses: pnpm/action-setup@v4
 
       - name: Use Node.js
-        if: ${{ steps.release.outputs.release_created }}
         uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: "pnpm"
 
       - name: Install dependencies
-        if: ${{ steps.release.outputs.release_created }}
         run: pnpm i --frozen-lockfile
 
       - name: Build package
-        if: ${{ steps.release.outputs.release_created }}
         run: pnpm build
 
       - name: Publish
-        if: ${{ steps.release.outputs.release_created }}
         run: pnpm publish --access public
+
+  deploy-gh-pages:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: release
+    if: ${{needs.release.outputs.release-created}}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm i --frozen-lockfile
+
+      - name: Build documentation
+        run: pnpm build:docs
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: docs
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
ci: deploy release documentation to GitHub Pages

ci: temporarily pin the next release version due to release tag changes