### PR TITLE
Remove CommonJS build and rely on require(esm) feature of modern runtimes/bundlers

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -17,9 +17,8 @@
 
 ## Introduction
 
-<img src="/app/src/images/unbikit-logo.svg" alt="logo of unbikit" width="24" height="24">
-unbikit (_un-bik-ɪt_) is a decoder for `.bik`
-([Bink Video](https://en.wikipedia.org/wiki/Bink_Video))
+<img src="/app/src/images/unbikit-logo.svg" alt="logo of unbikit" width="24" height="24"> unbikit
+(_un-bik-ɪt_) is a decoder for `.bik` ([Bink Video](https://en.wikipedia.org/wiki/Bink_Video))
 files that can be used to play or transcode videos using the Web Streams API.
 The format was first released in 1999 and has since been used in many classic computer games.
 
@@ -49,6 +48,8 @@ To use it:
 
 ```typescript
 import { BikDecoder, type BikFrame } from "unbikit";
+// or for CommonJS:
+//   const { BikDecoder } = require("unbikit");
 
 let stream: ReadableStream;
 // ... assign a source to the stream

--- a/README.md
+++ b/README.md
@@ -6,9 +6,8 @@
 > ⚠️
 > This package is at an early development stage. Expect API changes!
 
-<img src="/app/src/images/unbikit-logo.svg" alt="logo of unbikit" width="24" height="24">
-unbikit (_un-bik-ɪt_) is a decoder for `.bik`
-([Bink Video](https://en.wikipedia.org/wiki/Bink_Video))
+<img src="/app/src/images/unbikit-logo.svg" alt="logo of unbikit" width="24" height="24"> unbikit
+(_un-bik-ɪt_) is a decoder for `.bik` ([Bink Video](https://en.wikipedia.org/wiki/Bink_Video))
 files that can be used to play or transcode videos using the Web Streams API.
 The format was first released in 1999 and has since been used in many classic computer games.
 

--- a/app/src/content/docs/getting-started.mdx
+++ b/app/src/content/docs/getting-started.mdx
@@ -14,6 +14,8 @@ To use it:
 
 ```typescript
 import { BikDecoder, type BikFrame } from "unbikit";
+// or for CommonJS:
+//   const { BikDecoder } = require("unbikit");
 
 let stream: ReadableStream;
 // ... assign a source to the stream

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.6/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.7/schema.json",
   "files": {
     "ignoreUnknown": false,
     "includes": [

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "type": "module",
   "sideEffects": false,
   "module": "./dist/unbikit.js",
-  "main": "./dist/unbikit.cjs",
   "engines": {
     "node": ">=22.18"
   },
@@ -95,29 +94,17 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/unbikit.d.ts",
       "development": "./src/bik-decoder.ts",
-      "import": {
-        "types": "./dist/unbikit.d.ts",
-        "default": "./dist/unbikit.js"
-      },
-      "require": {
-        "types": "./dist/unbikit.d.cts",
-        "default": "./dist/unbikit.cjs"
-      }
+      "default": "./dist/unbikit.js"
     },
     "./package.json": "./package.json"
   },
   "publishConfig": {
     "exports": {
       ".": {
-        "import": {
-          "types": "./dist/unbikit.d.ts",
-          "default": "./dist/unbikit.js"
-        },
-        "require": {
-          "types": "./dist/unbikit.d.cts",
-          "default": "./dist/unbikit.cjs"
-        }
+        "types": "./dist/unbikit.d.ts",
+        "default": "./dist/unbikit.js"
       },
       "./package.json": "./package.json"
     }

--- a/src/bik-decoder.ts
+++ b/src/bik-decoder.ts
@@ -10,6 +10,7 @@
  *
  * @packageDocumentation
  */
+
 import { BikAudioDecoder } from "./bik-audio-decoder.ts";
 import { BikVideoDecoder, type BikVideoFrame } from "./bik-video-decoder.ts";
 

--- a/tests/__snapshots__/main.test.ts.snap
+++ b/tests/__snapshots__/main.test.ts.snap
@@ -319,3 +319,43 @@ exports[`decode corner cases > should decode a video, reset the decoder then dec
 exports[`decode corner cases > should decode a video, reset the decoder then decode the video again > screenshot_testfile06_frame_276.png 1`] = `"df56de7a7a097ebeffb4335851ad9903a7f4ba58fa39f185311ff1fc8856b4c2"`;
 
 exports[`decode corner cases > should decode a video, reset the decoder then decode the video again > screenshot_testfile06_frame_276.png 2`] = `"df56de7a7a097ebeffb4335851ad9903a7f4ba58fa39f185311ff1fc8856b4c2"`;
+
+exports[`support require() > should support the use of require(esm) for loading the package > numTracks_audio_testfile06_frame_0 1`] = `1`;
+
+exports[`support require() > should support the use of require(esm) for loading the package > numTracks_audio_testfile06_frame_69 1`] = `1`;
+
+exports[`support require() > should support the use of require(esm) for loading the package > numTracks_audio_testfile06_frame_138 1`] = `1`;
+
+exports[`support require() > should support the use of require(esm) for loading the package > numTracks_audio_testfile06_frame_207 1`] = `1`;
+
+exports[`support require() > should support the use of require(esm) for loading the package > numTracks_audio_testfile06_frame_276 1`] = `1`;
+
+exports[`support require() > should support the use of require(esm) for loading the package > sampleBytes_audio_testfile06_frame_0 1`] = `276480`;
+
+exports[`support require() > should support the use of require(esm) for loading the package > sampleBytes_audio_testfile06_frame_69 1`] = `15360`;
+
+exports[`support require() > should support the use of require(esm) for loading the package > sampleBytes_audio_testfile06_frame_138 1`] = `15360`;
+
+exports[`support require() > should support the use of require(esm) for loading the package > sampleBytes_audio_testfile06_frame_207 1`] = `15360`;
+
+exports[`support require() > should support the use of require(esm) for loading the package > sampleBytes_audio_testfile06_frame_276 1`] = `0`;
+
+exports[`support require() > should support the use of require(esm) for loading the package > sampleHash_audio_testfile06_frame_0 1`] = `"33adbc02ff11ffc118c4e927132c8b7839e372b66bffad14e2dd3b9106c475dd"`;
+
+exports[`support require() > should support the use of require(esm) for loading the package > sampleHash_audio_testfile06_frame_69 1`] = `"0299f757a85a1aad6cbe1ad2b0eda925d8df667cd04e646af8917f65cbf24537"`;
+
+exports[`support require() > should support the use of require(esm) for loading the package > sampleHash_audio_testfile06_frame_138 1`] = `"0299f757a85a1aad6cbe1ad2b0eda925d8df667cd04e646af8917f65cbf24537"`;
+
+exports[`support require() > should support the use of require(esm) for loading the package > sampleHash_audio_testfile06_frame_207 1`] = `"0299f757a85a1aad6cbe1ad2b0eda925d8df667cd04e646af8917f65cbf24537"`;
+
+exports[`support require() > should support the use of require(esm) for loading the package > sampleHash_audio_testfile06_frame_276 1`] = `"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"`;
+
+exports[`support require() > should support the use of require(esm) for loading the package > screenshot_testfile06_frame_0.png 1`] = `"e8817a7782d0cabbdb5e1d2cad4995c67146a7765bbaf185ff9fe3f9ff43797d"`;
+
+exports[`support require() > should support the use of require(esm) for loading the package > screenshot_testfile06_frame_69.png 1`] = `"e2a6c449292f77ef98f890e837da6a3257619c8f9c756ad6d8771fb47da9a260"`;
+
+exports[`support require() > should support the use of require(esm) for loading the package > screenshot_testfile06_frame_138.png 1`] = `"43e0fc4e1d4c962cad5c940d629f211557b9cc9cde1ba8e0e3c60a8de40c0394"`;
+
+exports[`support require() > should support the use of require(esm) for loading the package > screenshot_testfile06_frame_207.png 1`] = `"35c612115979c5aabf3136b26103679df4ac3f00da311875682506ede6219088"`;
+
+exports[`support require() > should support the use of require(esm) for loading the package > screenshot_testfile06_frame_276.png 1`] = `"df56de7a7a097ebeffb4335851ad9903a7f4ba58fa39f185311ff1fc8856b4c2"`;

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -141,3 +141,15 @@ suite("decode corner cases", async () => {
     await fetchSelectionOfFrames("testfile06", { annotate, expect }, decoder);
   });
 });
+
+suite("support require()", async () => {
+  test("should support the use of require(esm) for loading the package", async ({
+    annotate,
+    expect,
+  }) => {
+    // Load the decoder with `require()` and decode a video to verify the decoder is functioning.
+    const { BikDecoder } = require("unbikit");
+    const decoder = await BikDecoder.open(mediaFiles["testfile06"].getStreamFn());
+    await fetchSelectionOfFrames("testfile06", { annotate, expect }, decoder);
+  });
+});

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -4,12 +4,12 @@ import { commonBuildInputOptions, commonBuildTestConfig } from "./common-build-t
 const config: UserConfig[] = defineConfig([
   {
     ...commonBuildTestConfig,
-    attw: true,
+    attw: { level: "error", profile: "esmOnly" },
     dts: true,
     entry: {
       unbikit: "./src/bik-decoder.ts",
     },
-    format: ["esm", "commonjs"],
+    format: ["esm"],
     fromVite: true, // import plugins from the Vite config
     inputOptions: commonBuildInputOptions,
     publint: true,


### PR DESCRIPTION
This removes the separate CommonJS build and instead requires a modern runtime (like all currently supported Node.js versions) or bundler that supports using `require()` to import an ESM.

Reference: [Shipping ESM for CommonJS consumers (Node.js guide)](https://github.com/nodejs/package-examples/blob/main/guide/04-cjs-esm-interop/shipping-esm-for-cjs/README.md)

* feat!: remove CommonJS build and rely on require(esm) feature of modern runtimes/bundlers
* test: add test of require(esm) functionality
* docs: improve logo placement