### PR TITLE
Modify API to use Blob/File/Request/URL as a video source (instead of the "stream provider" function)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,4 +4,4 @@ insert_final_newline = true
 end_of_line = lf
 indent_style = space
 indent_size = 2
-max_line_length = 100
+max_line_length = 99

--- a/.github/README.md
+++ b/.github/README.md
@@ -12,15 +12,12 @@
 [![PNPM badge](https://img.shields.io/badge/pnpm-4a4a4a.svg?style=for-the-badge&logo=pnpm&logoColor=f69220)](https://pnpm.io)
 [![Conventional Commits badge](https://img.shields.io/badge/Conventional%20Commits-1.0.0-FE5196?style=for-the-badge&logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
 
-> [!WARNING]
-> This package is at an early development stage. Expect API changes!
-
 ## Introduction
 
 <img src="/app/src/images/unbikit-logo.svg" alt="logo of unbikit" width="24" height="24"> unbikit
 (_un-bik-ɪt_) is a decoder for `.bik` ([Bink Video](https://en.wikipedia.org/wiki/Bink_Video))
-files that can be used to play or transcode videos using the Web Streams API.
-The format was first released in 1999 and has since been used in many classic computer games.
+files that can be used to play or transcode videos. The format was first released in 1999 and has
+since been used in many classic computer games.
 
 ⭐ [Documentation](https://blennies.github.io/unbikit/) and a
 ⭐ [video player demo](https://blennies.github.io/unbikit/demo/) are available!
@@ -29,9 +26,10 @@ The format was first released in 1999 and has since been used in many classic co
 
 - Supports Bink 1, revisions `c` to `i` inclusive
 - Handles demuxing and decompression of audio and video streams
-- TypeScript/JavaScript only (no WASM or native code)
+- TypeScript/JavaScript (no WASM or native code)
 - No dependencies
-- Uses Web Streams API for efficient reading of video data
+- Straightforward API: supply a video via `Blob`, `File`, `Request` or `URL`
+  - the Web Streams API will be used where possible for efficient reading of video data
 - Isomorphic
   - runs on client/server runtimes that support at least ES2022
   - can be run with older runtimes by using the syntax lowering feature of some bundlers
@@ -47,13 +45,11 @@ npm install unbikit
 To use it:
 
 ```typescript
-import { BikDecoder, type BikFrame } from "unbikit";
+import { createBikDecoder, type BikFrame } from "unbikit";
 // or for CommonJS:
-//   const { BikDecoder } = require("unbikit");
+//   const { createBikDecoder } = require("unbikit");
 
-let stream: ReadableStream;
-// ... assign a source to the stream
-const decoder = await BikDecoder.open(() => stream);
+const decoder = await createBikDecoder(new URL("/some/source/of/video.bik"));
 let frame: BikFrame | null;
 while ((frame = await decoder?.getNextFrame())) {
   // ... process frame

--- a/README.md
+++ b/README.md
@@ -3,13 +3,10 @@
 [![minzipped bundle size](https://img.shields.io/bundlephobia/minzip/unbikit?style=flat-square)](https://bundlephobia.com/package/unbikit)
 [![types included](https://img.shields.io/npm/types/unbikit?style=flat-square)](https://www.npmjs.com/package/unbikit)
 
-> ⚠️
-> This package is at an early development stage. Expect API changes!
-
 <img src="/app/src/images/unbikit-logo.svg" alt="logo of unbikit" width="24" height="24"> unbikit
 (_un-bik-ɪt_) is a decoder for `.bik` ([Bink Video](https://en.wikipedia.org/wiki/Bink_Video))
-files that can be used to play or transcode videos using the Web Streams API.
-The format was first released in 1999 and has since been used in many classic computer games.
+files that can be used to play or transcode videos. The format was first released in 1999 and has
+since been used in many classic computer games.
 
 ⭐ [Documentation](https://blennies.github.io/unbikit/) and a
 ⭐ [video player demo](https://blennies.github.io/unbikit/demo/)
@@ -20,9 +17,10 @@ are available, as well as a
 
 - Supports Bink 1, revisions `c` to `i` inclusive
 - Handles demuxing and decompression of audio and video streams
-- TypeScript/JavaScript only (no WASM or native code)
+- TypeScript/JavaScript (no WASM or native code)
 - No dependencies
-- Uses Web Streams API for efficient reading of video data
+- Straightforward API: supply a video via `Blob`, `File`, `Request` or `URL`
+  - the Web Streams API will be used where possible for efficient reading of video data
 - Isomorphic
   - runs on client/server runtimes that support at least ES2022
   - can be run with older runtimes by using the syntax lowering feature of some bundlers

--- a/app/src/components/bik-player-audioworklet.ts
+++ b/app/src/components/bik-player-audioworklet.ts
@@ -61,7 +61,10 @@ class BikAudioProcessor extends AudioWorkletProcessor {
             for (const [channelIndex, channel] of outputChannels.entries()) {
               const audioData = queueAudioData[channelIndex];
               if (channelIndex > 0 && audioData) {
-                channel.set(audioData.subarray(this.#curPos, this.#curPos + samplesToCopy), outPos);
+                channel.set(
+                  audioData.subarray(this.#curPos, this.#curPos + samplesToCopy),
+                  outPos,
+                );
               }
             }
 

--- a/app/src/components/bik-player.ts
+++ b/app/src/components/bik-player.ts
@@ -133,7 +133,10 @@ export class BikPlayer {
     if (this.audioContext && this.gainNode) {
       // Fade out audio rapidly to avoid "clicking"
       this.gainNode.gain.setValueAtTime(this.gainNode.gain.value, this.audioContext.currentTime);
-      this.gainNode.gain.exponentialRampToValueAtTime(0.0001, this.audioContext.currentTime + 0.03);
+      this.gainNode.gain.exponentialRampToValueAtTime(
+        0.0001,
+        this.audioContext.currentTime + 0.03,
+      );
       await sleep(0.03);
     }
     this.worker.postMessage({ type: "stop", payload: null });

--- a/app/src/content/docs/getting-started.mdx
+++ b/app/src/content/docs/getting-started.mdx
@@ -13,13 +13,11 @@ To install the decoder:
 To use it:
 
 ```typescript
-import { BikDecoder, type BikFrame } from "unbikit";
+import { createBikDecoder, type BikFrame } from "unbikit";
 // or for CommonJS:
-//   const { BikDecoder } = require("unbikit");
+//   const { createBikDecoder } = require("unbikit");
 
-let stream: ReadableStream;
-// ... assign a source to the stream
-const decoder = await BikDecoder.open(() => stream);
+const decoder = await createBikDecoder(new URL("/some/source/of/video.bik"));
 let frame: BikFrame | null;
 while ((frame = await decoder?.getNextFrame())) {
   // ... process frame

--- a/app/src/content/docs/index.mdx
+++ b/app/src/content/docs/index.mdx
@@ -22,31 +22,26 @@ badge](https://img.shields.io/badge/pnpm-4a4a4a.svg?style=for-the-badge&logo=pnp
 [![Conventional Commits
 badge](https://img.shields.io/badge/Conventional%20Commits-1.0.0-FE5196?style=for-the-badge&logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
 
-:::caution
-This package is at an early development stage. Expect API changes!
-:::
-
 ## Introduction
 
-<Logo width="24" height="24" style="float: left; margin-right: 0.5rem;" />
-unbikit (_un-bik-ɪt_) is a decoder for `.bik` ([Bink
-Video](https://en.wikipedia.org/wiki/Bink_Video)) files that can be used to play or transcode videos
-using the Web Streams API. The format was first released in 1999 and has since been used in many
-classic computer games.
+<Logo width="24" height="24" style="float: left; margin-right: 0.5rem;" /> unbikit (_un-bik-ɪt_) is
+a decoder for `.bik` ([Bink Video](https://en.wikipedia.org/wiki/Bink_Video)) files that can be
+used to play or transcode videos. The format was first released in 1999 and has since been used in
+many classic computer games.
 
 This site hosts the documentation for the decoder, as well as a
 ⭐ [video player demo](/unbikit/demo) and other information.
 
-There is also a
-[repository page on GitHub](https://github.com/blennies/unbikit)!
+There is also a [repository page on GitHub](https://github.com/blennies/unbikit)!
 
 ### Features
 
 - Supports Bink 1, revisions `c` to `i` inclusive
 - Handles demuxing and decompression of audio and video streams
-- TypeScript/JavaScript only (no WASM or native code)
+- TypeScript/JavaScript (no WASM or native code)
 - No dependencies
-- Uses Web Streams API for efficient reading of video files
+- Straightforward API: supply a video via `Blob`, `File`, `Request` or `URL`
+  - the Web Streams API will be used where possible for efficient reading of video data
 - Isomorphic
   - runs on client/server runtimes that support at least ES2022
   - can be run with older runtimes by using the syntax lowering feature of some bundlers

--- a/app/src/pages/demo.astro
+++ b/app/src/pages/demo.astro
@@ -943,7 +943,9 @@ import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
     });
 
     volumeSlider.addEventListener("input", (e) => {
-      changeVolume(((e?.target as HTMLInputElement | undefined)?.value as number | undefined) ?? 0);
+      changeVolume(
+        ((e?.target as HTMLInputElement | undefined)?.value as number | undefined) ?? 0
+      );
     });
 
     // Initialize

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -29,7 +29,8 @@
   "formatter": {
     "enabled": true,
     "indentStyle": "space",
-    "lineWidth": 100
+    "lineWidth": 99,
+    "useEditorconfig": true
   },
   "linter": {
     "enabled": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2116,8 +2116,8 @@ packages:
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
 
-  mdast-util-to-hast@13.2.0:
-    resolution: {integrity: sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==}
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
 
   mdast-util-to-markdown@2.1.2:
     resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
@@ -5058,7 +5058,7 @@ snapshots:
       hast-util-from-parse5: 8.0.3
       hast-util-to-parse5: 8.0.0
       html-void-elements: 3.0.0
-      mdast-util-to-hast: 13.2.0
+      mdast-util-to-hast: 13.2.1
       parse5: 7.3.0
       unist-util-position: 5.0.0
       unist-util-visit: 5.0.0
@@ -5113,7 +5113,7 @@ snapshots:
       comma-separated-tokens: 2.0.3
       hast-util-whitespace: 3.0.0
       html-void-elements: 3.0.0
-      mdast-util-to-hast: 13.2.0
+      mdast-util-to-hast: 13.2.1
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
       stringify-entities: 4.0.4
@@ -5560,7 +5560,7 @@ snapshots:
       '@types/mdast': 4.0.4
       unist-util-is: 6.0.1
 
-  mdast-util-to-hast@13.2.0:
+  mdast-util-to-hast@13.2.1:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
@@ -6176,7 +6176,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      mdast-util-to-hast: 13.2.0
+      mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
 

--- a/src/bik-video-decoder.ts
+++ b/src/bik-video-decoder.ts
@@ -206,7 +206,10 @@ export class BikVideoDecoder {
     for (let i = 0; i < NUM_BLOCK_PARAMS; i++) {
       (this.#blockParams[i as IntRange<0, typeof NUM_BLOCK_PARAMS>] as BlockParamValues) = {
         len_: 0,
-        tree_: { tableNum_: 0, symbolMap_: new Uint8Array(16) as FixedLenUint8Array<16> },
+        tree_: {
+          tableNum_: 0,
+          symbolMap_: new Uint8Array(16) as FixedLenUint8Array<16>,
+        },
         items_: new Uint8Array(blocks * 64),
         curDec_: 0,
         curPtr_: 0,
@@ -708,7 +711,11 @@ export class BikVideoDecoder {
       }
 
       if (isRun) {
-        blockParamValues.items_.fill(v, blockParamValues.curDec_, blockParamValues.curDec_ + count);
+        blockParamValues.items_.fill(
+          v,
+          blockParamValues.curDec_,
+          blockParamValues.curDec_ + count,
+        );
         blockParamValues.curDec_ += count;
       } else {
         blockParamValues.items_[blockParamValues.curDec_++] = v;

--- a/tests/__snapshots__/main.test.ts.snap
+++ b/tests/__snapshots__/main.test.ts.snap
@@ -320,42 +320,22 @@ exports[`decode corner cases > should decode a video, reset the decoder then dec
 
 exports[`decode corner cases > should decode a video, reset the decoder then decode the video again > screenshot_testfile06_frame_276.png 2`] = `"df56de7a7a097ebeffb4335851ad9903a7f4ba58fa39f185311ff1fc8856b4c2"`;
 
-exports[`support require() > should support the use of require(esm) for loading the package > numTracks_audio_testfile06_frame_0 1`] = `1`;
+exports[`support different usage options > should support the use of require(esm) for loading the package > numTracks_audio_testfile02_frame_0 1`] = `0`;
 
-exports[`support require() > should support the use of require(esm) for loading the package > numTracks_audio_testfile06_frame_69 1`] = `1`;
+exports[`support different usage options > should support the use of require(esm) for loading the package > numTracks_audio_testfile02_frame_42 1`] = `0`;
 
-exports[`support require() > should support the use of require(esm) for loading the package > numTracks_audio_testfile06_frame_138 1`] = `1`;
+exports[`support different usage options > should support the use of require(esm) for loading the package > numTracks_audio_testfile02_frame_84 1`] = `0`;
 
-exports[`support require() > should support the use of require(esm) for loading the package > numTracks_audio_testfile06_frame_207 1`] = `1`;
+exports[`support different usage options > should support the use of require(esm) for loading the package > numTracks_audio_testfile02_frame_126 1`] = `0`;
 
-exports[`support require() > should support the use of require(esm) for loading the package > numTracks_audio_testfile06_frame_276 1`] = `1`;
+exports[`support different usage options > should support the use of require(esm) for loading the package > numTracks_audio_testfile02_frame_168 1`] = `0`;
 
-exports[`support require() > should support the use of require(esm) for loading the package > sampleBytes_audio_testfile06_frame_0 1`] = `276480`;
+exports[`support different usage options > should support the use of require(esm) for loading the package > screenshot_testfile02_frame_0.png 1`] = `"f3af0ab2b08a5de7419316d9ac0d2c38c118ae95e3a8547b03b2ea23e75c4484"`;
 
-exports[`support require() > should support the use of require(esm) for loading the package > sampleBytes_audio_testfile06_frame_69 1`] = `15360`;
+exports[`support different usage options > should support the use of require(esm) for loading the package > screenshot_testfile02_frame_42.png 1`] = `"ec33abba11e19da2b3effc10b1c14e5d7b2bf8acc1cbff1615ed55109d8717c2"`;
 
-exports[`support require() > should support the use of require(esm) for loading the package > sampleBytes_audio_testfile06_frame_138 1`] = `15360`;
+exports[`support different usage options > should support the use of require(esm) for loading the package > screenshot_testfile02_frame_84.png 1`] = `"229b794f104cfd0cd58397cc484e50d2c73082701529bc70f917650efba0f8c1"`;
 
-exports[`support require() > should support the use of require(esm) for loading the package > sampleBytes_audio_testfile06_frame_207 1`] = `15360`;
+exports[`support different usage options > should support the use of require(esm) for loading the package > screenshot_testfile02_frame_126.png 1`] = `"67dd689300abff49e9ef684f176fa66737a37b2f60e1c061c84d291fa677c0d4"`;
 
-exports[`support require() > should support the use of require(esm) for loading the package > sampleBytes_audio_testfile06_frame_276 1`] = `0`;
-
-exports[`support require() > should support the use of require(esm) for loading the package > sampleHash_audio_testfile06_frame_0 1`] = `"33adbc02ff11ffc118c4e927132c8b7839e372b66bffad14e2dd3b9106c475dd"`;
-
-exports[`support require() > should support the use of require(esm) for loading the package > sampleHash_audio_testfile06_frame_69 1`] = `"0299f757a85a1aad6cbe1ad2b0eda925d8df667cd04e646af8917f65cbf24537"`;
-
-exports[`support require() > should support the use of require(esm) for loading the package > sampleHash_audio_testfile06_frame_138 1`] = `"0299f757a85a1aad6cbe1ad2b0eda925d8df667cd04e646af8917f65cbf24537"`;
-
-exports[`support require() > should support the use of require(esm) for loading the package > sampleHash_audio_testfile06_frame_207 1`] = `"0299f757a85a1aad6cbe1ad2b0eda925d8df667cd04e646af8917f65cbf24537"`;
-
-exports[`support require() > should support the use of require(esm) for loading the package > sampleHash_audio_testfile06_frame_276 1`] = `"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"`;
-
-exports[`support require() > should support the use of require(esm) for loading the package > screenshot_testfile06_frame_0.png 1`] = `"e8817a7782d0cabbdb5e1d2cad4995c67146a7765bbaf185ff9fe3f9ff43797d"`;
-
-exports[`support require() > should support the use of require(esm) for loading the package > screenshot_testfile06_frame_69.png 1`] = `"e2a6c449292f77ef98f890e837da6a3257619c8f9c756ad6d8771fb47da9a260"`;
-
-exports[`support require() > should support the use of require(esm) for loading the package > screenshot_testfile06_frame_138.png 1`] = `"43e0fc4e1d4c962cad5c940d629f211557b9cc9cde1ba8e0e3c60a8de40c0394"`;
-
-exports[`support require() > should support the use of require(esm) for loading the package > screenshot_testfile06_frame_207.png 1`] = `"35c612115979c5aabf3136b26103679df4ac3f00da311875682506ede6219088"`;
-
-exports[`support require() > should support the use of require(esm) for loading the package > screenshot_testfile06_frame_276.png 1`] = `"df56de7a7a097ebeffb4335851ad9903a7f4ba58fa39f185311ff1fc8856b4c2"`;
+exports[`support different usage options > should support the use of require(esm) for loading the package > screenshot_testfile02_frame_168.png 1`] = `"f3af0ab2b08a5de7419316d9ac0d2c38c118ae95e3a8547b03b2ea23e75c4484"`;

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -5,6 +5,7 @@
  * Test valid BIK 1 files that should be decoded correctly, along with valid BIK 1b and 2 files
  * that the decoder should refuse to decode but handle gracefully.
  */
+
 import { suite, type TestContext, test } from "vitest";
 import type { BikDecoder } from "../src/bik-decoder.ts";
 import { frameToPng, getMediaFileDecoder, getShaSum, mediaFiles } from "./common.ts";
@@ -142,14 +143,14 @@ suite("decode corner cases", async () => {
   });
 });
 
-suite("support require()", async () => {
+suite("support different usage options", async () => {
   test("should support the use of require(esm) for loading the package", async ({
     annotate,
     expect,
   }) => {
     // Load the decoder with `require()` and decode a video to verify the decoder is functioning.
-    const { BikDecoder } = require("unbikit");
-    const decoder = await BikDecoder.open(mediaFiles["testfile06"].getStreamFn());
-    await fetchSelectionOfFrames("testfile06", { annotate, expect }, decoder);
+    const { createBikDecoder } = require("unbikit");
+    const decoder = await createBikDecoder(await mediaFiles["testfile02"].getBlob());
+    await fetchSelectionOfFrames("testfile02", { annotate, expect }, decoder);
   });
 });


### PR DESCRIPTION
feat!: modify API to use Blob/File/Request/URL as a video source

BREAKING CHANGE: remove the API that required a "stream provider" function

Make the API much more straightforward to setup and use. The decoder handles the generation of streams as required, either by using either the Fetch API or Blob API.

test: update tests based on API changes

docs: update based on API changes

docs: remove "early development" warning

style: fix formatting of line lengths in source files

build(deps-dev): update dependencies