### PR TITLE
ci: fix `release-and-publish` job failure caused by invalid Node.js cache option

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -25,7 +25,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: "pnpm"
 
       - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859
         id: app-token


### PR DESCRIPTION
ci: fix `release-and-publish` job failure caused by invalid Node.js cache option