### PR TITLE
ci: attempt to fix automation of approving and merging of Dependabot PRs

### DIFF
--- a/.github/workflows/automate-dependabot.yml
+++ b/.github/workflows/automate-dependabot.yml
@@ -1,28 +1,22 @@
-name: Automated Dependabot approve + merge
-on:
-  workflow_run:
-    workflows:
-      - check-build-test
-    branches-ignore:
-      - main
-    types:
-      - completed
+name: Automated Dependabot approve + auto-merge
+on: pull_request
 
 permissions:
+  contents: write
   pull-requests: write
 
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]' && github.event.workflow_run.conclusion == 'success'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a
+        uses: dependabot/fetch-metadata@ffa630c65fa7e0ecfa0625b5ceda64399aea1b36
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Approve and merge Dependabot PR
-        run: gh pr review --approve "$PR_URL" && gh pr merge --rebase --delete-branch "$PR_URL"
+      - name: Approve and enable auto-merge for Dependabot PRs
+        run: gh pr review --approve "$PR_URL" && gh pr merge --auto --rebase --squash --delete-branch "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
ci: attempt to fix automation of approving and merging of Dependabot PRs

Attempt based on [these instructions](https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/automating-dependabot-with-github-actions#enabling-automerge-on-a-pull-request).